### PR TITLE
fix: only join to pg_constraint on primary key

### DIFF
--- a/dgw.go
+++ b/dgw.go
@@ -74,7 +74,7 @@ FROM pg_attribute a
 JOIN ONLY pg_class c ON c.oid = a.attrelid
 JOIN ONLY pg_namespace n ON n.oid = c.relnamespace
 LEFT JOIN pg_constraint ct ON ct.conrelid = c.oid
-AND a.attnum = ANY(ct.conkey) AND ct.contype IN ('p', 'u')
+AND a.attnum = ANY(ct.conkey) AND ct.contype = 'p'
 LEFT JOIN pg_attrdef ad ON ad.adrelid = c.oid AND ad.adnum = a.attnum
 WHERE a.attisdropped = false
 AND n.nspname = $1


### PR DESCRIPTION
Hi achiku,

Thanks for the great library, I really like that you can give a custom typemap file.

Whilst testing it out I found some fields where being duplicated in the output structs, and it turned out it was because they were being used in multiple unique indexes and so being brought in multiple times, this PR drops the join on unique indexes and limits it to primary key. I don't think this affects the rest of the query as `ct.contype` only seems to be used if it is a primary key column, but I might have misunderstood the query.

Thanks again.