### PR TITLE
Drop extra info from data type

### DIFF
--- a/dgw.go
+++ b/dgw.go
@@ -8,6 +8,7 @@ import (
 	"go/format"
 	"io/ioutil"
 	"sort"
+	"strings"
 	"text/template"
 
 	"github.com/BurntSushi/toml"
@@ -200,6 +201,13 @@ func PgLoadColumnDef(db Queryer, schema string, table string) ([]*PgColumn, erro
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to scan")
 		}
+
+		// Some data types have an extra part e.g, "character varying(16)" and
+		// "numeric(10, 5)". We want to drop the extra part.
+		if i := strings.Index(c.DataType, "("); i > 0 {
+			c.DataType = c.DataType[0:i]
+		}
+
 		cols = append(cols, c)
 	}
 	return cols, nil


### PR DESCRIPTION
Problem:

Some data types have an extra part e.g, "character varying(16)".
Currently those data types are outputted as "interface{}" because they
won't match with the default type map. However we want to output those
types as correct go type e.g., "character varying" to "string".

Solution:

Drop the extra part from data type when loading column definitions.