### PR TITLE
Remove usage of deprecated 'adsrc' column

### DIFF
--- a/dgw.go
+++ b/dgw.go
@@ -56,7 +56,7 @@ SELECT
              SELECT 1 FROM pg_attrdef ad
              WHERE  ad.adrelid = a.attrelid
              AND    ad.adnum   = a.attnum
-             AND    ad.adsrc = 'nextval('''
+             AND    pg_get_expr(ad.adbin, ad.adrelid) = 'nextval('''
                 || (pg_get_serial_sequence (a.attrelid::regclass::text
                                           , a.attname))::regclass
                 || '''::regclass)'


### PR DESCRIPTION
Hi, Thank you for creating a useful tool!

I noticed that `dgw` did not work with Postgres 12 due to the removal of the `adsrc` column.
This PR removes the use of 'adsrc' column which was removed in Postgres 12.

To make sure this change was correct, I checked that the following two SQLs returned the same results in Postgres 9.5.

```
SELECT adsrc FROM pg_attrdef;
SELECT pg_get_expr(adbin, adrelid) FROM pg_attrdef;
```